### PR TITLE
Add message file logging

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -44,5 +44,9 @@
                 "Text" : "no-message"
             }
         }
+    },
+    "Logging" : {
+        "Enabled" : false,
+        "Path" : "ps-utilities.log"
     }
 }

--- a/docs/how-to/enable-logging.md
+++ b/docs/how-to/enable-logging.md
@@ -1,0 +1,11 @@
+# Enable message logging
+
+Messages written via `Message2` can also be persisted to a log file. The location is controlled via the `Logging` section of the module configuration.
+
+```powershell
+# enable logging and set a custom path
+(PSUtilConfig).Logging.Enabled = $true
+(PSUtilConfig).Logging.Path = 'my-log.txt'
+```
+
+When enabled, each call to `Message2` will append the formatted log entry to the specified path.

--- a/public/functions.ps1
+++ b/public/functions.ps1
@@ -212,13 +212,28 @@ function Message2{
         }
 
         if(($preferences.($message.Type).Enabled)){
-            write-host ("[+] [{0}]::[{1}]::[{2}]::[{3}]::[{4}]" -f @(
-                $message.Type
-                $message.DateTime
-                $message.From
-                $message.UserName
+            $logEntry = "[+] [{0}]::[{1}]::[{2}]::[{3}]::[{4}]" -f @(
+                $message.Type,
+                $message.DateTime,
+                $message.From,
+                $message.UserName,
                 $message.Text
-            )) -fore $preferences.($message.Type).color
+            )
+
+            write-host $logEntry -fore $preferences.($message.Type).color
+
+            $logging = (PSUtilConfig).Logging
+            if($null -ne $logging -and $logging.Enabled){
+                $logPath = $logging.Path
+                if(-not [System.IO.Path]::IsPathRooted($logPath)){
+                    $logPath = Join-Path $HOME $logPath
+                }
+                $logDir = Split-Path -Path $logPath -Parent
+                if(-not (Test-Path -Path $logDir)){
+                    New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+                }
+                Add-Content -Path $logPath -Value $logEntry
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- allow messages to be logged to a file when enabled
- expose `Logging` configuration section with `Enabled` and `Path`
- document how to enable message logging

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester -Path tests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa52b058c8327bf49dbc741e8ae6e